### PR TITLE
Add landing page linking to both demos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - work
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # dummy-mobile-application
 A modern UI routing application
+
+## GitHub Pages Deployment
+
+A GitHub Actions workflow is included to automatically deploy the site whenever
+you push to `main` or `work`. The workflow uploads the current directory and publishes
+it as a GitHub Pages site.
+
+The repository uses a simple landing page (`index.html`) that links to two demos:
+`final_drum_gemini_demo_app.html` and `final_drum_seek_demo_app.html`. After pushing
+your changes to GitHub:
+
+1. Open the repository on GitHub and go to **Settings** > **Pages**.
+2. Under **Source**, choose the branch you want to publish from (e.g., `main` or `work`) and the root directory.
+3. Save the settings and GitHub Pages will serve the application. Navigate to the landing page and select a demo, or access the HTML files directly.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DRUM Demo Applications</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 2rem; }
+        h1 { margin-bottom: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>DRUM Demo Applications</h1>
+    <ul>
+        <li><a href="final_drum_gemini_demo_app.html">Gemini Demo</a></li>
+        <li><a href="final_drum_seek_demo_app.html">Seek Demo</a></li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- keep Gemini demo file alongside Seek demo
- create new `index.html` landing page linking to both demos
- document new landing page and how to enable GitHub Pages

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b028c4f7c8330942246c40867a258